### PR TITLE
update plugin to new api

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 sudo: false
+jdk:
+ - oraclejdk8
 language: ruby
 cache: bundler
 rvm:
-  - jruby-1.7.23
-script: 
-  - bundle exec rspec spec
+ - jruby-1.7.25
+script:
+ - bundle exec rspec spec

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
   - relax contraints on logstash-core-plugin-api
   - Update .travis.yml
   - Freeze google-api-client and mime-types
+  - use concurrency :single
 
 ## 2.0.4
   - Depend on logstash-core-plugin-api instead of logstash-core, removing the need to mass update plugins on major releases of logstash

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,20 @@
-# 2.0.4
+## 3.0.0
+  - Breaking: Updated plugin to use new Java Event APIs
+  - relax contraints on logstash-core-plugin-api
+  - Update .travis.yml
+  - Freeze google-api-client and mime-types
+
+## 2.0.4
   - Depend on logstash-core-plugin-api instead of logstash-core, removing the need to mass update plugins on major releases of logstash
-# 2.0.3
+
+## 2.0.3
   - New dependency requirements for logstash-core for the 5.0 release
+
 ## 2.0.0
  - Plugins were updated to follow the new shutdown semantic, this mainly allows Logstash to instruct input plugins to terminate gracefully, 
    instead of using Thread.raise on the plugins' threads. Ref: https://github.com/elastic/logstash/pull/3895
  - Dependency on logstash-core update to 2.0
 
-# 0.2.0
+## 0.2.0
   - Changed the Google Cloud Storage API version to v1
   - Added simple test for plugin lookup

--- a/lib/logstash/outputs/google_cloud_storage.rb
+++ b/lib/logstash/outputs/google_cloud_storage.rb
@@ -1,4 +1,3 @@
-
 # encoding: utf-8
 # Author: Rodrigo De Castro <rdc@google.com>
 # Date: 2013-09-20
@@ -18,6 +17,7 @@
 # limitations under the License.
 require "logstash/outputs/base"
 require "logstash/namespace"
+require "logstash/json"
 require "zlib"
 
 # Summary: plugin to upload log events to Google Cloud Storage (GCS), rolling
@@ -67,6 +67,8 @@ require "zlib"
 # exposed by Ruby API client)
 class LogStash::Outputs::GoogleCloudStorage < LogStash::Outputs::Base
   config_name "google_cloud_storage"
+
+  concurrency :single
 
   # GCS bucket name, without "gs://" or any other prefix.
   config :bucket, :validate => :string, :required => true
@@ -135,12 +137,10 @@ class LogStash::Outputs::GoogleCloudStorage < LogStash::Outputs::Base
   # file, flushing depending on flush interval configuration.
   public
   def receive(event)
-    
-
     @logger.debug("GCS: receive method called", :event => event)
 
     if (@output_format == "json")
-      message = event.to_json
+      message = LogStash::Json.dump(event.to_hash)
     else
       message = event.to_s
     end

--- a/logstash-output-google_cloud_storage.gemspec
+++ b/logstash-output-google_cloud_storage.gemspec
@@ -1,7 +1,6 @@
 Gem::Specification.new do |s|
-
   s.name            = 'logstash-output-google_cloud_storage'
-  s.version         = '2.0.4'
+  s.version         = '3.0.0'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "plugin to upload log events to Google Cloud Storage (GCS)"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"
@@ -20,11 +19,12 @@ Gem::Specification.new do |s|
   s.metadata = { "logstash_plugin" => "true", "logstash_group" => "output" }
 
   # Gem dependencies
-  s.add_runtime_dependency "logstash-core-plugin-api", "~> 1.0"
+  s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
 
   s.add_runtime_dependency 'stud'
-  s.add_runtime_dependency 'google-api-client'
+  s.add_runtime_dependency 'google-api-client', '0.8.7'
   s.add_runtime_dependency 'logstash-codec-plain'
+  s.add_runtime_dependency 'mime-types', '2.6.2'
 
   s.add_development_dependency 'logstash-devutils'
 end


### PR DESCRIPTION
  - Breaking: Updated plugin to use new Java Event APIs
  - relax contraints on logstash-core-plugin-api
  - Update .travis.yml
  - Freeze google-api-client and mime-types