### PR TITLE
Align dependencies with logstash-output-google_bigquery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.0.1
+  - align the dependency on mime-type and google-api-client with the `logstash-output-google_bigquery`
+
 ## 3.0.0
   - Breaking: Updated plugin to use new Java Event APIs
   - relax contraints on logstash-core-plugin-api

--- a/logstash-output-google_cloud_storage.gemspec
+++ b/logstash-output-google_cloud_storage.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-output-google_cloud_storage'
-  s.version         = '3.0.0'
+  s.version         = '3.0.1'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "plugin to upload log events to Google Cloud Storage (GCS)"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"
@@ -22,9 +22,9 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
 
   s.add_runtime_dependency 'stud'
-  s.add_runtime_dependency 'google-api-client', '0.8.7'
+  s.add_runtime_dependency 'google-api-client', '~> 0.8.7' # version 0.9.x works only with ruby 2.x
   s.add_runtime_dependency 'logstash-codec-plain'
-  s.add_runtime_dependency 'mime-types', '2.6.2'
+  s.add_runtime_dependency 'mime-types', '~> 2' # last version compatible with ruby 2.x
 
   s.add_development_dependency 'logstash-devutils'
 end


### PR DESCRIPTION
Relax dependencies on google-api-client and mime-types to ensure better
compatible with others plugins like the google bigquery

This PR is made from a discussion with @jsvd on this PR https://github.com/logstash-plugins/logstash-output-google_bigquery/pull/23