### PR TITLE
removing hostname from file name

### DIFF
--- a/lib/logstash/outputs/google_cloud_storage.rb
+++ b/lib/logstash/outputs/google_cloud_storage.rb
@@ -259,7 +259,7 @@ class LogStash::Outputs::GoogleCloudStorage < LogStash::Outputs::Base
   # max file or gzip options.
   def get_base_path
     return @temp_directory + File::SEPARATOR + @log_file_prefix + "_" +
-      Socket.gethostname() + "_" + Time.now.strftime(@date_pattern)
+      Time.now.strftime(@date_pattern)
   end
 
   ##


### PR DESCRIPTION
I don't think there is a need to relay on outside information to create these files.

I have a case that I'm using logstash inside a docker container, every time I deploy a new version of the configuration the hostname changes (since it's a new container) so old files left in the mounted folder aren't been uploaded.

I removed the hostname, believe it can assist everyone.

Thanks.