### PR TITLE
Add configuration option to set `Content-Encoding` to `gzip`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,21 @@
+---
 sudo: false
-jdk:
- - oraclejdk8
 language: ruby
 cache: bundler
+env:
 rvm:
- - jruby-1.7.25
-script:
- - bundle exec rspec spec
+  - jruby-1.7.25
+matrix:
+  include:
+    - rvm: jruby-1.7.25
+      env: LOGSTASH_BRANCH=master
+    - rvm: jruby-1.7.25
+      env: LOGSTASH_BRANCH=5.x
+    - rvm: jruby-9.1.9.0
+      env: LOGSTASH_BRANCH=feature/9000
+  allow_failures:
+    - rvm: jruby-9.1.9.0
+  fast_finish: true
+install: true
+script: ci/build.sh
+jdk: oraclejdk8

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.0.2
+  - Docs: Fix doc formatting
+
 ## 3.0.1
   - align the dependency on mime-type and google-api-client with the `logstash-output-google_bigquery`
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,10 @@
 source 'https://rubygems.org'
+
 gemspec
+
+logstash_path = "../../logstash"
+
+if Dir.exist?(logstash_path) && ENV["LOGSTASH_SOURCE"] == 1
+  gem 'logstash-core', :path => "#{logstash_path}/logstash-core"
+  gem 'logstash-core-plugin-api', :path => "#{logstash_path}/logstash-core-plugin-api"
+end

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# version: 1
+########################################################
+#
+# AUTOMATICALLY GENERATED! DO NOT EDIT
+#
+########################################################
+set -e
+
+echo "Starting build process in: `pwd`"
+./ci/setup.sh
+
+if [[ -f "ci/run.sh" ]]; then
+    echo "Running custom build script in: `pwd`/ci/run.sh"
+    ./ci/run.sh
+else
+    echo "Running default build scripts in: `pwd`/ci/build.sh"
+    bundle install
+    bundle exec rake vendor
+    bundle exec rspec spec
+fi

--- a/ci/setup.sh
+++ b/ci/setup.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# version: 1
+########################################################
+#
+# AUTOMATICALLY GENERATED! DO NOT EDIT
+#
+########################################################
+set -e
+if [ "$LOGSTASH_BRANCH" ]; then
+    echo "Building plugin using Logstash source"
+    BASE_DIR=`pwd`
+    echo "Checking out branch: $LOGSTASH_BRANCH"
+    git clone -b $LOGSTASH_BRANCH https://github.com/elastic/logstash.git ../../logstash --depth 1
+    printf "Checked out Logstash revision: %s\n" "$(git -C ../../logstash rev-parse HEAD)"
+    cd ../../logstash
+    echo "Building plugins with Logstash version:"
+    cat versions.yml
+    echo "---"
+    # We need to build the jars for that specific version
+    echo "Running gradle assemble in: `pwd`"
+    ./gradlew assemble
+    cd $BASE_DIR
+    export LOGSTASH_SOURCE=1
+else
+    echo "Building plugin using released gems on rubygems"
+fi

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -148,8 +148,17 @@ added[3.3.0]
   * Value type is <<boolean,boolean>>
   * Default value is `false`
 
-Gzip output stream when writing events to log files and set
-`Content-Encoding` to `gzip`.
+Gzip output stream when writing events to log files and set `Content-Encoding` to `gzip`.
+This will upload your files as `gzip` saving network and storage costs, but they will be
+transparently decompressed when you read them from the storage bucket.
+
+See the Cloud Storage documentation on https://cloud.google.com/storage/docs/metadata#content-encoding[metadata] and 
+https://cloud.google.com/storage/docs/transcoding#content-type_vs_content-encoding[transcoding]
+for more information.
+
+**Note**: It is not recommended to use both `gzip_content_encoding` and `gzip`.
+This compresses your file _twice_, will increase the work your machine does and makes 
+the files larger than just compressing once.
 
 [id="plugins-{type}s-{plugin}-include_hostname"]
 ===== `include_hostname`

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -1,0 +1,205 @@
+:plugin: google_cloud_storage
+:type: output
+
+///////////////////////////////////////////
+START - GENERATED VARIABLES, DO NOT EDIT!
+///////////////////////////////////////////
+:version: %VERSION%
+:release_date: %RELEASE_DATE%
+:changelog_url: %CHANGELOG_URL%
+:include_path: ../../../logstash/docs/include
+///////////////////////////////////////////
+END - GENERATED VARIABLES, DO NOT EDIT!
+///////////////////////////////////////////
+
+[id="plugins-{type}-{plugin}"]
+
+=== Google_cloud_storage
+
+include::{include_path}/plugin_header.asciidoc[]
+
+==== Description
+
+Summary: plugin to upload log events to Google Cloud Storage (GCS), rolling
+files based on the date pattern provided as a configuration setting. Events
+are written to files locally and, once file is closed, this plugin uploads
+it to the configured bucket.
+
+For more info on Google Cloud Storage, please go to:
+https://cloud.google.com/products/cloud-storage
+
+In order to use this plugin, a Google service account must be used. For
+more information, please refer to:
+https://developers.google.com/storage/docs/authentication#service_accounts
+
+Recommendation: experiment with the settings depending on how much log
+data you generate, so the uploader can keep up with the generated logs.
+Using gzip output can be a good option to reduce network traffic when
+uploading the log files and in terms of storage costs as well.
+
+USAGE:
+This is an example of logstash config:
+
+[source,json]
+--------------------------
+output {
+   google_cloud_storage {
+     bucket => "my_bucket"                                     (required)
+     key_path => "/path/to/privatekey.p12"                     (required)
+     key_password => "notasecret"                              (optional)
+     service_account => "1234@developer.gserviceaccount.com"   (required)
+     temp_directory => "/tmp/logstash-gcs"                     (optional)
+     log_file_prefix => "logstash_gcs"                         (optional)
+     max_file_size_kbytes => 1024                              (optional)
+     output_format => "plain"                                  (optional)
+     date_pattern => "%Y-%m-%dT%H:00"                          (optional)
+     flush_interval_secs => 2                                  (optional)
+     gzip => false                                             (optional)
+     uploader_interval_secs => 60                              (optional)
+   }
+}
+--------------------------
+
+* Support logstash event variables to determine filename.
+* Turn Google API code into a Plugin Mixin (like AwsConfig).
+* There's no recover method, so if logstash/plugin crashes, files may not
+be uploaded to GCS.
+* Allow user to configure file name.
+* Allow parallel uploads for heavier loads (+ connection configuration if
+exposed by Ruby API client)
+
+[id="plugins-{type}s-{plugin}-options"]
+==== Google_cloud_storage Output Configuration Options
+
+This plugin supports the following configuration options plus the <<plugins-{type}s-common-options>> described later.
+
+[cols="<,<,<",options="header",]
+|=======================================================================
+|Setting |Input type|Required
+| <<plugins-{type}s-{plugin}-bucket>> |<<string,string>>|Yes
+| <<plugins-{type}s-{plugin}-date_pattern>> |<<string,string>>|No
+| <<plugins-{type}s-{plugin}-flush_interval_secs>> |<<number,number>>|No
+| <<plugins-{type}s-{plugin}-gzip>> |<<boolean,boolean>>|No
+| <<plugins-{type}s-{plugin}-key_password>> |<<string,string>>|No
+| <<plugins-{type}s-{plugin}-key_path>> |<<string,string>>|Yes
+| <<plugins-{type}s-{plugin}-log_file_prefix>> |<<string,string>>|No
+| <<plugins-{type}s-{plugin}-max_file_size_kbytes>> |<<number,number>>|No
+| <<plugins-{type}s-{plugin}-output_format>> |<<string,string>>, one of `["json", "plain"]`|No
+| <<plugins-{type}s-{plugin}-service_account>> |<<string,string>>|Yes
+| <<plugins-{type}s-{plugin}-temp_directory>> |<<string,string>>|No
+| <<plugins-{type}s-{plugin}-uploader_interval_secs>> |<<number,number>>|No
+|=======================================================================
+
+Also see <<plugins-{type}s-common-options>> for a list of options supported by all
+output plugins.
+
+&nbsp;
+
+[id="plugins-{type}s-{plugin}-bucket"]
+===== `bucket` 
+
+  * This is a required setting.
+  * Value type is <<string,string>>
+  * There is no default value for this setting.
+
+GCS bucket name, without "gs://" or any other prefix.
+
+[id="plugins-{type}s-{plugin}-date_pattern"]
+===== `date_pattern` 
+
+  * Value type is <<string,string>>
+  * Default value is `"%Y-%m-%dT%H:00"`
+
+Time pattern for log file, defaults to hourly files.
+Must Time.strftime patterns: www.ruby-doc.org/core-2.0/Time.html#method-i-strftime
+
+[id="plugins-{type}s-{plugin}-flush_interval_secs"]
+===== `flush_interval_secs` 
+
+  * Value type is <<number,number>>
+  * Default value is `2`
+
+Flush interval in seconds for flushing writes to log files. 0 will flush
+on every message.
+
+[id="plugins-{type}s-{plugin}-gzip"]
+===== `gzip` 
+
+  * Value type is <<boolean,boolean>>
+  * Default value is `false`
+
+Gzip output stream when writing events to log files.
+
+[id="plugins-{type}s-{plugin}-key_password"]
+===== `key_password` 
+
+  * Value type is <<string,string>>
+  * Default value is `"notasecret"`
+
+GCS private key password.
+
+[id="plugins-{type}s-{plugin}-key_path"]
+===== `key_path` 
+
+  * This is a required setting.
+  * Value type is <<string,string>>
+  * There is no default value for this setting.
+
+GCS path to private key file.
+
+[id="plugins-{type}s-{plugin}-log_file_prefix"]
+===== `log_file_prefix` 
+
+  * Value type is <<string,string>>
+  * Default value is `"logstash_gcs"`
+
+Log file prefix. Log file will follow the format:
+<prefix>_hostname_date<.part?>.log
+
+[id="plugins-{type}s-{plugin}-max_file_size_kbytes"]
+===== `max_file_size_kbytes` 
+
+  * Value type is <<number,number>>
+  * Default value is `10000`
+
+Sets max file size in kbytes. 0 disable max file check.
+
+[id="plugins-{type}s-{plugin}-output_format"]
+===== `output_format` 
+
+  * Value can be any of: `json`, `plain`
+  * Default value is `"plain"`
+
+The event format you want to store in files. Defaults to plain text.
+
+[id="plugins-{type}s-{plugin}-service_account"]
+===== `service_account` 
+
+  * This is a required setting.
+  * Value type is <<string,string>>
+  * There is no default value for this setting.
+
+GCS service account.
+
+[id="plugins-{type}s-{plugin}-temp_directory"]
+===== `temp_directory` 
+
+  * Value type is <<string,string>>
+  * Default value is `""`
+
+Directory where temporary files are stored.
+Defaults to /tmp/logstash-gcs-<random-suffix>
+
+[id="plugins-{type}s-{plugin}-uploader_interval_secs"]
+===== `uploader_interval_secs` 
+
+  * Value type is <<number,number>>
+  * Default value is `60`
+
+Uploader interval when uploading new files to GCS. Adjust time based
+on your time pattern (for example, for hourly files, this interval can be
+around one hour).
+
+
+
+include::{include_path}/{type}.asciidoc[]

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -55,6 +55,7 @@ output {
      date_pattern => "%Y-%m-%dT%H:00"                          (optional)
      flush_interval_secs => 2                                  (optional)
      gzip => false                                             (optional)
+     gzip_content_encoding => false                            (optional)
      uploader_interval_secs => 60                              (optional)
    }
 }
@@ -80,6 +81,7 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 | <<plugins-{type}s-{plugin}-date_pattern>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-flush_interval_secs>> |<<number,number>>|No
 | <<plugins-{type}s-{plugin}-gzip>> |<<boolean,boolean>>|No
+| <<plugins-{type}s-{plugin}-gzip_content_encoding>> |<<boolean,boolean>>|No
 | <<plugins-{type}s-{plugin}-key_password>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-key_path>> |<<string,string>>|Yes
 | <<plugins-{type}s-{plugin}-log_file_prefix>> |<<string,string>>|No
@@ -128,7 +130,18 @@ on every message.
   * Value type is <<boolean,boolean>>
   * Default value is `false`
 
-Gzip output stream when writing events to log files.
+Gzip output stream when writing events to log files, set
+`Content-Type` to `application/gzip` instead of `text/plain`, and
+use file suffix `.log.gz` instead of `.log`.
+
+[id="plugins-{type}s-{plugin}-gzip_content_encoding"]
+===== `gzip_content_encoding`
+
+  * Value type is <<boolean,boolean>>
+  * Default value is `false`
+
+Gzip output stream when writing events to log files and set
+`Content-Encoding` to `gzip`.
 
 [id="plugins-{type}s-{plugin}-key_password"]
 ===== `key_password` 

--- a/lib/logstash/outputs/google_cloud_storage.rb
+++ b/lib/logstash/outputs/google_cloud_storage.rb
@@ -1,3 +1,5 @@
+# [source,txt]
+# -----
 # encoding: utf-8
 # Author: Rodrigo De Castro <rdc@google.com>
 # Date: 2013-09-20
@@ -15,6 +17,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+# -----
 require "logstash/outputs/base"
 require "logstash/namespace"
 require "logstash/json"
@@ -40,6 +43,8 @@ require "zlib"
 # USAGE:
 # This is an example of logstash config:
 #
+# [source,json]
+# --------------------------
 # output {
 #    google_cloud_storage {
 #      bucket => "my_bucket"                                     (required)
@@ -56,14 +61,15 @@ require "zlib"
 #      uploader_interval_secs => 60                              (optional)
 #    }
 # }
+# --------------------------
 #
 # Improvements TODO list:
-# - Support logstash event variables to determine filename.
-# - Turn Google API code into a Plugin Mixin (like AwsConfig).
-# - There's no recover method, so if logstash/plugin crashes, files may not
+# * Support logstash event variables to determine filename.
+# * Turn Google API code into a Plugin Mixin (like AwsConfig).
+# * There's no recover method, so if logstash/plugin crashes, files may not
 # be uploaded to GCS.
-# - Allow user to configure file name.
-# - Allow parallel uploads for heavier loads (+ connection configuration if
+# * Allow user to configure file name.
+# * Allow parallel uploads for heavier loads (+ connection configuration if
 # exposed by Ruby API client)
 class LogStash::Outputs::GoogleCloudStorage < LogStash::Outputs::Base
   config_name "google_cloud_storage"

--- a/logstash-output-google_cloud_storage.gemspec
+++ b/logstash-output-google_cloud_storage.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   # Files
-  s.files = Dir['lib/**/*','spec/**/*','vendor/**/*','*.gemspec','*.md','CONTRIBUTORS','Gemfile','LICENSE','NOTICE.TXT']
+  s.files = Dir["lib/**/*","spec/**/*","*.gemspec","*.md","CONTRIBUTORS","Gemfile","LICENSE","NOTICE.TXT", "vendor/jar-dependencies/**/*.jar", "vendor/jar-dependencies/**/*.rb", "VERSION", "docs/**/*"]
 
   # Tests
   s.test_files = s.files.grep(%r{^(test|spec|features)/})

--- a/logstash-output-google_cloud_storage.gemspec
+++ b/logstash-output-google_cloud_storage.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-output-google_cloud_storage'
-  s.version         = '3.0.1'
+  s.version         = '3.0.2'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "plugin to upload log events to Google Cloud Storage (GCS)"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
This is separate from the pre-existing `gzip` setting, which uploads the content as an actual `.gz` file. This pull request addresses issue #13.

For an explanation of why a separate setting is useful/needful, [see this link here from the GCS docs](https://cloud.google.com/storage/docs/transcoding#content-type_vs_content-encoding).


