### PR TITLE
Avoid upload file when size = 0

### DIFF
--- a/lib/logstash/outputs/google_cloud_storage.rb
+++ b/lib/logstash/outputs/google_cloud_storage.rb
@@ -251,7 +251,13 @@ class LogStash::Outputs::GoogleCloudStorage < LogStash::Outputs::Base
           end
         end
 
-        upload_object(filename)
+        if File.stat(filename).size > 0
+          upload_object(filename)
+        else
+          @logger.debug("GCS: file size is zero, skip upload.",
+                         :filename => filename,
+                         :filesize => File.stat(filename).size)
+        end
         @logger.debug("GCS: delete local temporary file ",
                       :filename => filename)
         File.delete(filename)


### PR DESCRIPTION
Upload file only file size > 0
To reduce GCS storage usage of metadata.