### PR TITLE
Log UUID inclusion, fixes #23

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.1.0
+  - Add support for disabling hostname in the log file names
+  - Add support for adding a UUID to the log file names
+
 ## 3.0.4
   - Fix some documentation issues
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -56,6 +56,8 @@ output {
      flush_interval_secs => 2                                  (optional)
      gzip => false                                             (optional)
      uploader_interval_secs => 60                              (optional)
+     include_uuid => true                                      (optional)
+     include_hostname => true                                  (optional)
    }
 }
 --------------------------
@@ -80,6 +82,8 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 | <<plugins-{type}s-{plugin}-date_pattern>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-flush_interval_secs>> |<<number,number>>|No
 | <<plugins-{type}s-{plugin}-gzip>> |<<boolean,boolean>>|No
+| <<plugins-{type}s-{plugin}-include_hostname>> |<<boolean,boolean>>|No
+| <<plugins-{type}s-{plugin}-include_uuid>> |<<boolean,boolean>>|No
 | <<plugins-{type}s-{plugin}-key_password>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-key_path>> |<<string,string>>|Yes
 | <<plugins-{type}s-{plugin}-log_file_prefix>> |<<string,string>>|No
@@ -129,6 +133,32 @@ on every message.
   * Default value is `false`
 
 Gzip output stream when writing events to log files.
+
+[id="plugins-{type}s-{plugin}-include_hostname"]
+===== `include_hostname`
+
+added[3.1.0]
+
+  * Value type is <<boolean,boolean>>
+  * Default value is `true`
+
+Should the hostname be included in the file name?
+You may want to turn this off for privacy reasons or if you are running multiple
+instances of Logstash and need to match the files you create with a simple glob
+such as if you wanted to import files to BigQuery.
+
+
+[id="plugins-{type}s-{plugin}-include_uuid"]
+===== `include_uuid`
+
+added[3.1.0]
+
+  * Value type is <<boolean,boolean>>
+  * Default value is `false`
+
+Adds a UUID to the end of a file name.
+You may want to enable this feature so files don't clobber one another if you're
+running multiple instances of Logstash or if you expect frequent node restarts.
 
 [id="plugins-{type}s-{plugin}-key_password"]
 ===== `key_password` 

--- a/lib/logstash/outputs/gcs/path_factory.rb
+++ b/lib/logstash/outputs/gcs/path_factory.rb
@@ -90,6 +90,27 @@ module LogStash
           @base_pattern % @current
         end
       end
+
+      # PathFactoryBuilder makes the long PathFactory constructor chain more readable.
+      class PathFactoryBuilder
+        def self.build
+          builder = new
+          yield builder
+          builder.build_path_factory
+        end
+
+        def self.builder_setter(*names)
+          names.each do |name|
+            define_method("set_#{name}") {|arg| instance_variable_set("@#{name}", arg)}
+          end
+        end
+
+        builder_setter :directory, :prefix, :include_host, :date_pattern, :include_part, :include_uuid, :is_gzipped
+
+        def build_path_factory
+          PathFactory.new(@directory, @prefix, @include_host, @date_pattern, @include_part, @include_uuid, @is_gzipped)
+        end
+      end
     end
   end
 end

--- a/lib/logstash/outputs/gcs/path_factory.rb
+++ b/lib/logstash/outputs/gcs/path_factory.rb
@@ -1,0 +1,95 @@
+# encoding: utf-8
+require 'thread'
+
+module LogStash
+  module Outputs
+    module Gcs
+      # PathFactory creates paths for rotating files.
+      class PathFactory
+        def initialize(directory, prefix, include_host, date_pattern, include_part, include_uuid, is_gzipped)
+          @path_lock = Mutex.new
+
+          pattern = '%{prefix}'
+          pattern += '_%{host}' if include_host
+          pattern += '_%{date}'
+          @base_pattern = pattern
+
+          pattern += '.part%{partf}' if include_part
+          pattern += '.%{uuid}' if include_uuid
+          pattern += '.log'
+          pattern += '.gz' if is_gzipped
+          @pattern = pattern
+
+          @prefix = prefix
+          @directory = directory
+          @date_pattern = date_pattern
+
+          @part_number = starting_part
+          @current = template_variables
+        end
+
+        # Rotates the path to the next one in sequence. If the path has a part number
+        # and the base path (date/hostname) haven't changed the part number is incremented.
+        def rotate_path!
+          @path_lock.synchronize {
+            @part_number = (next_base == current_base) ? @part_number + 1 : 0
+            @current = template_variables
+          }
+
+          current_path
+        end
+
+        # Checks if the file is ready to rotate because the timestamp changed.
+        def should_rotate?
+          @path_lock.synchronize {
+            next_base != current_base
+          }
+        end
+
+        # Returns the full path to the current file including parent directory.
+        def current_path(vars=nil)
+          @path_lock.synchronize {
+            filename = @pattern % (vars || @current)
+            ::File.join(@directory, filename)
+          }
+        end
+
+        private
+
+        # search through the directory for a file with the same base, and if it exists,
+        # set our part to be the max + 1 so we don't clobber existing files.
+        def starting_part
+          return 0 unless ::File.directory? @directory
+
+          base_path = ::File.join(@directory, next_base)
+
+          part_numbers = Dir.glob(base_path + '.part*').map do |item|
+            match = /^.*\.part(?<part_num>\d+).*$/.match(item)
+            next if match.nil?
+            match[:part_num].to_i
+          end
+
+          part_numbers.any? ? part_numbers.max + 1 : 0
+        end
+
+        def template_variables
+          {
+              prefix: @prefix,
+              host: Socket.gethostname,
+              date: Time.now.strftime(@date_pattern),
+              partf: '%03d' % @part_number,
+              uuid: SecureRandom.uuid
+          }
+        end
+
+        def next_base
+          @base_pattern % template_variables
+        end
+
+        def current_base
+          @base_pattern % @current
+        end
+      end
+    end
+  end
+end

--- a/lib/logstash/outputs/google_cloud_storage.rb
+++ b/lib/logstash/outputs/google_cloud_storage.rb
@@ -118,6 +118,12 @@ class LogStash::Outputs::GoogleCloudStorage < LogStash::Outputs::Base
   # around one hour).
   config :uploader_interval_secs, :validate => :number, :default => 60
 
+  # Should the hostname be included in the file name?
+  config :include_hostname, :validate => :boolean, :default => true
+
+  # Should a UUID be included in the file name?
+  config :include_uuid, :validate => :boolean, :default => false
+
   public
   def register
     require "fileutils"
@@ -128,7 +134,17 @@ class LogStash::Outputs::GoogleCloudStorage < LogStash::Outputs::Base
     @last_flush_cycle = Time.now
     initialize_upload_queue()
     initialize_temp_directory()
-    initialize_current_log()
+    @path_factory = Logstash::Outputs::Gcs::PathFactory.new(
+        @temp_directory,
+        @log_file_prefix,
+        @include_hostname,
+        @date_pattern,
+        @max_file_size_kbytes > 0,
+        @include_uuid,
+        @gzip
+    )
+    open_current_file
+
     initialize_google_client()
     @uploader = start_uploader
 
@@ -151,10 +167,8 @@ class LogStash::Outputs::GoogleCloudStorage < LogStash::Outputs::Base
       message = event.to_s
     end
 
-    new_base_path = get_base_path()
-
     # Time to roll file based on the date pattern? Or is it over the size limit?
-    if (@current_base_path != new_base_path || (@max_file_size_kbytes > 0 && @temp_file.size >= @max_file_size_kbytes * 1024))
+    if (@path_factory.should_rotate? || (@max_file_size_kbytes > 0 && @temp_file.size >= @max_file_size_kbytes * 1024))
       @logger.debug("GCS: log file will be closed and uploaded",
                     :filename => File.basename(@temp_file.to_path),
                     :size => @temp_file.size.to_s,
@@ -239,7 +253,7 @@ class LogStash::Outputs::GoogleCloudStorage < LogStash::Outputs::Base
 
     # Reenqueue if it is still the current file.
     if filename == @temp_file.to_path
-      if @current_base_path == get_base_path()
+      if !@path_factory.should_rotate?
         @logger.debug("GCS: reenqueue as log file is being currently appended to.",
                       :filename => filename)
         @upload_queue << filename
@@ -270,54 +284,11 @@ class LogStash::Outputs::GoogleCloudStorage < LogStash::Outputs::Base
   end
 
   ##
-  # Returns base path to log file that is invariant regardless of whether
-  # max file or gzip options.
-  def get_base_path
-    return @temp_directory + File::SEPARATOR + @log_file_prefix + "_" +
-      Socket.gethostname() + "_" + Time.now.strftime(@date_pattern)
-  end
-
-  ##
-  # Returns log file suffix, which will vary depending on whether gzip is
-  # enabled.
-  def get_suffix
-    return @gzip ? ".log.gz" : ".log"
-  end
-
-  ##
-  # Returns full path to the log file based on global variables (like
-  # current_base_path) and configuration options (max file size and gzip
-  # enabled).
-  def get_full_path
-    if @max_file_size_kbytes > 0
-      return @current_base_path + ".part" + ("%03d" % @size_counter) + get_suffix()
-    else
-      return @current_base_path + get_suffix()
-    end
-  end
-
-  ##
-  # Returns latest part number for a base path. This method checks all existing
-  # log files in order to find the highest part number, so this file can be used
-  # for appending log events.
-  #
-  # Only applicable if max file size is enabled.
-  def get_latest_part_number(base_path)
-    part_numbers = Dir.glob(base_path + ".part*" + get_suffix()).map do |item|
-      match = /^.*\.part(?<part_num>\d+)#{get_suffix()}$/.match(item)
-      next if match.nil?
-      match[:part_num].to_i
-    end
-
-    return part_numbers.max if part_numbers.any?
-    0
-  end
-
-  ##
   # Opens current log file and updates @temp_file with an instance of IOWriter.
   # This method also adds file to the upload queue.
   def open_current_file()
-    path = get_full_path()
+    path = @path_factory.current_path
+
     stat = File.stat(path) rescue nil
     if stat and stat.ftype == "fifo" and RUBY_PLATFORM == "java"
       fd = java.io.FileWriter.new(java.io.File.new(path))
@@ -332,36 +303,12 @@ class LogStash::Outputs::GoogleCloudStorage < LogStash::Outputs::Base
   end
 
   ##
-  # Opens log file on plugin initialization, trying to resume from an existing
-  # file. If max file size is enabled, find the highest part number and resume
-  # from it.
-  def initialize_current_log
-    @current_base_path = get_base_path
-    if @max_file_size_kbytes > 0
-      @size_counter = get_latest_part_number(@current_base_path)
-      @logger.debug("GCS: resuming from latest part.",
-                    :part => @size_counter)
-    end
-    open_current_file()
-  end
-
-  ##
   # Generates new log file name based on configuration options and opens log
   # file. If max file size is enabled, part number if incremented in case the
   # the base log file name is the same (e.g. log file was not rolled given the
   # date pattern).
   def initialize_next_log
-    new_base_path = get_base_path
-    if @max_file_size_kbytes > 0
-      @size_counter = @current_base_path == new_base_path ? @size_counter + 1 : 0
-      @logger.debug("GCS: opening next log file.",
-                    :filename => @current_base_path,
-                    :part => @size_counter)
-    else
-      @logger.debug("GCS: opening next log file.",
-                    :filename => @current_base_path)
-    end
-    @current_base_path = new_base_path
+    @path_factory.rotate_path!
     open_current_file()
   end
 

--- a/lib/logstash/outputs/google_cloud_storage.rb
+++ b/lib/logstash/outputs/google_cloud_storage.rb
@@ -230,15 +230,15 @@ class LogStash::Outputs::GoogleCloudStorage < LogStash::Outputs::Base
   end
 
   def initialize_path_factory
-    @path_factory = LogStash::Outputs::Gcs::PathFactory.new(
-        @temp_directory,
-        @log_file_prefix,
-        @include_hostname,
-        @date_pattern,
-        @max_file_size_kbytes > 0,
-        @include_uuid,
-        @gzip
-    )
+    @path_factory = LogStash::Outputs::Gcs::PathFactoryBuilder.build do |builder|
+      builder.set_directory @temp_directory
+      builder.set_prefix @log_file_prefix
+      builder.set_include_host @include_hostname
+      builder.set_date_pattern @date_pattern
+      builder.set_include_part(@max_file_size_kbytes > 0)
+      builder.set_include_uuid @include_uuid
+      builder.set_is_gzipped @gzip
+    end
   end
 
   def start_uploader
@@ -285,7 +285,6 @@ class LogStash::Outputs::GoogleCloudStorage < LogStash::Outputs::Base
     @logger.debug("GCS: delete local temporary file ",
                   :filename => filename)
     File.delete(filename)
-    sleep @uploader_interval_secs
   end
 
   ##

--- a/lib/logstash/outputs/google_cloud_storage.rb
+++ b/lib/logstash/outputs/google_cloud_storage.rb
@@ -125,12 +125,12 @@ class LogStash::Outputs::GoogleCloudStorage < LogStash::Outputs::Base
 
     @logger.debug("GCS: register plugin")
 
-    @upload_queue = Queue.new
     @last_flush_cycle = Time.now
+    initialize_upload_queue()
     initialize_temp_directory()
     initialize_current_log()
     initialize_google_client()
-    initialize_uploader()
+    @uploader = start_uploader
 
     if @gzip
       @content_type = 'application/gzip'
@@ -222,48 +222,51 @@ class LogStash::Outputs::GoogleCloudStorage < LogStash::Outputs::Base
     end
   end
 
-  ##
-  # Starts thread to upload log files.
-  #
-  # Uploader is done in a separate thread, not holding the receive method above.
-  def initialize_uploader
-    @uploader = Thread.new do
+  def start_uploader
+    Thread.new do
       @logger.debug("GCS: starting uploader")
       while true
-        filename = @upload_queue.pop
-
-        # Reenqueue if it is still the current file.
-        if filename == @temp_file.to_path
-          if @current_base_path == get_base_path()
-            @logger.debug("GCS: reenqueue as log file is being currently appended to.",
-                          :filename => filename)
-            @upload_queue << filename
-            # If we got here, it means that older files were uploaded, so let's
-            # wait another minute before checking on this file again.
-            sleep @uploader_interval_secs
-            next
-          else
-            @logger.debug("GCS: flush and close file to be uploaded.",
-                          :filename => filename)
-            @temp_file.fsync()
-            @temp_file.close()
-            initialize_next_log()
-          end
-        end
-
-        if File.stat(filename).size > 0
-          upload_object(filename)
-        else
-          @logger.debug("GCS: file size is zero, skip upload.",
-                         :filename => filename,
-                         :filesize => File.stat(filename).size)
-        end
-        @logger.debug("GCS: delete local temporary file ",
-                      :filename => filename)
-        File.delete(filename)
-        sleep @uploader_interval_secs
+        upload_from_queue()
       end
     end
+  end
+  ##
+  # Uploads log files.
+  #
+  # Uploader is done in a separate thread, not holding the receive method above.
+  def upload_from_queue
+    filename = @upload_queue.pop
+
+    # Reenqueue if it is still the current file.
+    if filename == @temp_file.to_path
+      if @current_base_path == get_base_path()
+        @logger.debug("GCS: reenqueue as log file is being currently appended to.",
+                      :filename => filename)
+        @upload_queue << filename
+        # If we got here, it means that older files were uploaded, so let's
+        # wait another minute before checking on this file again.
+        sleep @uploader_interval_secs
+        return
+      else
+        @logger.debug("GCS: flush and close file to be uploaded.",
+                      :filename => filename)
+        @temp_file.fsync()
+        @temp_file.close()
+        initialize_next_log()
+      end
+    end
+
+    if File.stat(filename).size > 0
+      upload_object(filename)
+    else
+      @logger.debug("GCS: file size is zero, skip upload.",
+                     :filename => filename,
+                     :filesize => File.stat(filename).size)
+    end
+    @logger.debug("GCS: delete local temporary file ",
+                  :filename => filename)
+    File.delete(filename)
+    sleep @uploader_interval_secs
   end
 
   ##
@@ -378,6 +381,15 @@ class LogStash::Outputs::GoogleCloudStorage < LogStash::Outputs::Base
                                                          'https://www.googleapis.com/auth/devstorage.read_write',
                                                          key)
     @client.authorization = service_account.authorize
+  end
+
+  # Initialize the queue that harbors files to be uploaded
+  def initialize_upload_queue
+    @upload_queue = new_upload_queue()
+  end
+
+  def new_upload_queue
+    Queue.new
   end
 
   ##

--- a/lib/logstash/outputs/google_cloud_storage.rb
+++ b/lib/logstash/outputs/google_cloud_storage.rb
@@ -19,6 +19,7 @@
 # limitations under the License.
 # -----
 require "logstash/outputs/base"
+require "logstash/outputs/gcs/path_factory"
 require "logstash/namespace"
 require "logstash/json"
 require "zlib"

--- a/lib/logstash/outputs/google_cloud_storage.rb
+++ b/lib/logstash/outputs/google_cloud_storage.rb
@@ -134,15 +134,7 @@ class LogStash::Outputs::GoogleCloudStorage < LogStash::Outputs::Base
     @last_flush_cycle = Time.now
     initialize_upload_queue()
     initialize_temp_directory()
-    @path_factory = Logstash::Outputs::Gcs::PathFactory.new(
-        @temp_directory,
-        @log_file_prefix,
-        @include_hostname,
-        @date_pattern,
-        @max_file_size_kbytes > 0,
-        @include_uuid,
-        @gzip
-    )
+    initialize_path_factory
     open_current_file
 
     initialize_google_client()
@@ -234,6 +226,18 @@ class LogStash::Outputs::GoogleCloudStorage < LogStash::Outputs::Base
                     :directory => @temp_directory)
       FileUtils.mkdir_p(@temp_directory)
     end
+  end
+
+  def initialize_path_factory
+    @path_factory = LogStash::Outputs::Gcs::PathFactory.new(
+        @temp_directory,
+        @log_file_prefix,
+        @include_hostname,
+        @date_pattern,
+        @max_file_size_kbytes > 0,
+        @include_uuid,
+        @gzip
+    )
   end
 
   def start_uploader

--- a/logstash-output-google_cloud_storage.gemspec
+++ b/logstash-output-google_cloud_storage.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-output-google_cloud_storage'
-  s.version         = '3.0.4'
+  s.version         = '3.1.0'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "plugin to upload log events to Google Cloud Storage (GCS)"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/outputs/gcs/path_factory_spec.rb
+++ b/spec/outputs/gcs/path_factory_spec.rb
@@ -1,0 +1,122 @@
+# encoding: utf-8
+require 'logstash/outputs/gcs/path_factory'
+
+describe LogStash::Outputs::Gcs::PathFactory do
+  describe '#initialize' do
+    it 'includes optional fields if requested' do
+      pf = LogStash::Outputs::Gcs::PathFactory.new(
+          'path/to/directory',
+          'prefix',
+          true,
+          '',
+          true,
+          true,
+          true
+      )
+
+      vars = {
+          prefix: 'prefix',
+          host: 'hostname',
+          date: '2018-01-01',
+          uuid: '00000000-0000-0000-0000-000000000000',
+          partf: '333'
+      }
+
+      expected = 'prefix_hostname_2018-01-01.part333.00000000-0000-0000-0000-000000000000.log.gz'
+      expected = File.join('path/to/directory', expected)
+
+      actual = pf.current_path(vars)
+
+      expect(actual).to eq(expected)
+    end
+
+    it 'excludes optional fields if not requested' do
+      pf = LogStash::Outputs::Gcs::PathFactory.new(
+          'path/to/directory',
+          'prefix',
+          false,
+          '',
+          false,
+          false,
+          false
+      )
+
+      vars = {
+          prefix: 'prefix',
+          host: 'hostname',
+          date: '2018-01-01',
+          uuid: '00000000-0000-0000-0000-000000000000',
+          partf: '333'
+      }
+
+      expected = 'prefix_2018-01-01.log'
+      expected = File.join('path/to/directory', expected)
+
+      actual = pf.current_path(vars)
+
+      expect(actual).to eq(expected)
+    end
+
+    it 'loads a path immediately' do
+      pf = LogStash::Outputs::Gcs::PathFactory.new('', '', false, '', false, false, false)
+
+      expect(pf.current_path).to_not eq(nil)
+    end
+
+    it 'recovers the starting part number' do
+      contents = ['pre_date.part009.log.gz', 'pre_date.part091.log.gz', 'pre_date.part000.log.gz']
+
+      allow(::File).to receive(:directory?).with('dir').and_return(true)
+      allow(Dir).to receive(:glob).and_return(contents)
+
+      pf = LogStash::Outputs::Gcs::PathFactory.new('dir', 'pre', false, 'date', true, false, false)
+
+      expect(pf.current_path).to include('part092')
+    end
+  end
+
+  describe 'rotate_path!' do
+    it 'increments the part number if the base has not changed' do
+      pf = LogStash::Outputs::Gcs::PathFactory.new('dir', 'pre', false, 'date', true, false, false)
+      expect(pf.current_path).to eq(File.join('dir', 'pre_date.part000.log'))
+
+      pf.rotate_path!
+      expect(pf.current_path).to eq(File.join('dir', 'pre_date.part001.log'))
+    end
+
+    it 'resets the part number if the base has changed' do
+      pf = LogStash::Outputs::Gcs::PathFactory.new('dir', 'pre', false, '%N', true, false, false)
+      expect(pf.current_path).to include('part000')
+
+      pf.rotate_path!
+      expect(pf.current_path).to include('part000')
+    end
+
+    it 'returns the current_path' do
+      pf = LogStash::Outputs::Gcs::PathFactory.new('dir', 'pre', false, 'date', true, false, false)
+      after = pf.rotate_path!
+      expect(after).to eq(File.join('dir', 'pre_date.part001.log'))
+    end
+  end
+
+  describe 'should_rotate?' do
+    it 'returns false when the times in the bases are the same' do
+      pf = LogStash::Outputs::Gcs::PathFactory.new('', '', false, '', false, false, false)
+      sleep 0.1
+      expect(pf.should_rotate?).to eq(false)
+    end
+
+    it 'returns true when the times in the bases are different' do
+      pf = LogStash::Outputs::Gcs::PathFactory.new('', '', false, '%N', false, false, false)
+      sleep 0.1
+      expect(pf.should_rotate?).to eq(true)
+    end
+  end
+
+  describe 'current_path' do
+    it 'joins the directory and filename' do
+      pf = LogStash::Outputs::Gcs::PathFactory.new('dir', 'pre', false, 'date', false, false, false)
+      expect(pf.current_path).to eq(File.join('dir', 'pre_date.log'))
+    end
+  end
+end

--- a/spec/outputs/google_cloud_storage_spec.rb
+++ b/spec/outputs/google_cloud_storage_spec.rb
@@ -32,7 +32,8 @@ describe LogStash::Outputs::GoogleCloudStorage do
       allow(subject).to receive(:new_upload_queue).and_return(upload_queue)
       subject.send(:initialize_upload_queue)
       subject.send(:initialize_temp_directory)
-      subject.send(:initialize_current_log)
+      subject.send(:initialize_path_factory)
+      subject.send(:open_current_file)
       current_file = upload_queue.pop
       File.write(current_file, content) if content
       upload_queue.push(current_file)

--- a/spec/outputs/google_cloud_storage_spec.rb
+++ b/spec/outputs/google_cloud_storage_spec.rb
@@ -1,12 +1,16 @@
 # encoding: utf-8
 require_relative "../spec_helper"
 require "google/api_client"
+require "tempfile"
 
 describe LogStash::Outputs::GoogleCloudStorage do
   
   let(:client) { double("google-client") }
   let(:service_account) { double("service-account") }
   let(:key)    { "key" }
+
+  subject { described_class.new(config) }
+  let(:config) { {"bucket" => "", "key_path" => "", "service_account" => "", "uploader_interval_secs" => 0.1 } }
 
   before(:each) do
     allow(Google::APIClient).to receive(:new).and_return(client)
@@ -18,7 +22,37 @@ describe LogStash::Outputs::GoogleCloudStorage do
   end
 
   it "should register without errors" do
-    plugin = LogStash::Plugin.lookup("output", "google_cloud_storage").new({"bucket" => "", "key_path" => "", "service_account" => ""})
-    expect { plugin.register }.to_not raise_error
+    expect { subject.register }.to_not raise_error
+  end
+
+  describe "file size based decider for uploading" do
+    let(:upload_queue) { Queue.new }
+    let(:content) { }
+    before(:each) do
+      allow(subject).to receive(:new_upload_queue).and_return(upload_queue)
+      subject.send(:initialize_upload_queue)
+      subject.send(:initialize_temp_directory)
+      subject.send(:initialize_current_log)
+      current_file = upload_queue.pop
+      File.write(current_file, content) if content
+      upload_queue.push(current_file)
+      subject.send(:initialize_next_log)
+    end
+
+    context "when spooled file is empty" do
+      let(:content) { nil }
+      it "doesn't get uploaded" do
+        expect(subject).to_not receive(:upload_object)
+        subject.send(:upload_from_queue)
+      end
+    end
+
+    context "when spooled file has content" do
+      let(:content) { "hello" }
+      it "gets uploaded" do
+        expect(subject).to receive(:upload_object)
+        subject.send(:upload_from_queue)
+      end
+    end
   end
 end


### PR DESCRIPTION
Adds new flags to turn on/off the hostname in the log file name and whether or not to include a UUID in the file. This will allow users to match files with a single wildcard (to aid them in importing to BigQuery or other systems) and ensures files won't clobber one another if multiple instances of Logstash are running or an instance cycles up and down quickly.