### PR TITLE
Use correct SPDX license code.

### DIFF
--- a/logstash-output-google_cloud_storage.gemspec
+++ b/logstash-output-google_cloud_storage.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-output-google_cloud_storage'
   s.version         = '3.1.0'
-  s.licenses        = ['Apache License (2.0)']
+  s.licenses        = ['Apache-2.0']
   s.summary         = "plugin to upload log events to Google Cloud Storage (GCS)"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"
   s.authors         = ["Elastic"]


### PR DESCRIPTION
Rubygems will complain unless this license code is a valid SPDX one.

https://spdx.org/licenses/Apache-2.0.html