### PR TITLE
Refactor queue to worker pool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 3.2.0
+  - Change uploads to use a job pool for better performance
+    - Fixes [#22](https://github.com/logstash-plugins/logstash-output-google_cloud_storage/issues/22) - Refactor Job Queue Architecture
+    - Fixes [#5](https://github.com/logstash-plugins/logstash-output-google_cloud_storage/issues/5) - Major Performance Issues
+  - Wait for files to upload before Logstash quits
+    - Fixes [#15](https://github.com/logstash-plugins/logstash-output-google_cloud_storage/issues/15) - Fails to upload files when Logstash exits
+
 ## 3.1.0
   - Add support for disabling hostname in the log file names
   - Add support for adding a UUID to the log file names

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -88,6 +88,7 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 | <<plugins-{type}s-{plugin}-key_password>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-key_path>> |<<string,string>>|Yes
 | <<plugins-{type}s-{plugin}-log_file_prefix>> |<<string,string>>|No
+| <<plugins-{type}s-{plugin}-max_concurrent_uploads>> |<<number,number>>|No
 | <<plugins-{type}s-{plugin}-max_file_size_kbytes>> |<<number,number>>|No
 | <<plugins-{type}s-{plugin}-output_format>> |<<string,string>>, one of `["json", "plain"]`|No
 | <<plugins-{type}s-{plugin}-service_account>> |<<string,string>>|Yes
@@ -186,6 +187,17 @@ GCS path to private key file.
 
 Log file prefix. Log file will follow the format:
 <prefix>_hostname_date<.part?>.log
+
+[id="plugins-{type}s-{plugin}-max_concurrent_uploads"]
+===== `max_concurrent_uploads`
+
+  * Value type is <<number,number>>
+  * Default value is `5`
+
+Sets the maximum number of concurrent uploads to Cloud Storage at a time.
+Uploads are I/O bound so it makes sense to tune this paramater with regards
+to the network bandwidth available and the latency between your server and
+Cloud Storage.
 
 [id="plugins-{type}s-{plugin}-max_file_size_kbytes"]
 ===== `max_file_size_kbytes` 

--- a/lib/logstash/outputs/gcs/worker_pool.rb
+++ b/lib/logstash/outputs/gcs/worker_pool.rb
@@ -1,0 +1,47 @@
+# encoding: utf-8
+require 'thread'
+require 'concurrent'
+
+module LogStash
+  module Outputs
+    module Gcs
+      # WorkerPool creates a pool of workers that can handle jobs.
+      class WorkerPool
+        attr_reader :workers
+
+        def initialize(max_threads, synchronous=false)
+          @synchronous = synchronous
+
+          # set queue depth to the be the same as the number of threads so
+          # there's at most one pending job each when the plugin quits
+          @workers = Concurrent::ThreadPoolExecutor.new(
+            min_threads: 1,
+            max_threads: max_threads,
+            max_queue: max_threads,
+            fallback_policy: :caller_runs
+          )
+        end
+
+        # Submits a job to the worker pool, raises an error if the pool has
+        # already been stopped.
+        def post(&block)
+          raise 'Pool already stopped' unless @workers.running?
+
+          if @synchronous
+            block.call
+          else
+            @workers.post do
+              block.call
+            end
+          end
+        end
+
+        # Stops the worker pool
+        def stop!
+          @workers.shutdown
+          @workers.wait_for_termination
+        end
+      end
+    end
+  end
+end

--- a/logstash-output-google_cloud_storage.gemspec
+++ b/logstash-output-google_cloud_storage.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-output-google_cloud_storage'
-  s.version         = '3.1.0'
-  s.licenses        = ['Apache License (2.0)']
+  s.version         = '3.2.0'
+  s.licenses        = ['Apache-2.0']
   s.summary         = "plugin to upload log events to Google Cloud Storage (GCS)"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"
   s.authors         = ["Elastic"]
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'google-api-client', '~> 0.8.7' # version 0.9.x works only with ruby 2.x
   s.add_runtime_dependency 'logstash-codec-plain'
   s.add_runtime_dependency 'mime-types', '~> 2' # last version compatible with ruby 2.x
-
+  s.add_runtime_dependency 'concurrent-ruby', '1.0.5'
   s.add_development_dependency 'logstash-devutils'
 end
 

--- a/logstash-output-google_cloud_storage.gemspec
+++ b/logstash-output-google_cloud_storage.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-output-google_cloud_storage'
   s.version         = '3.2.0'
-  s.licenses        = ['Apache-2.0']
+  s.licenses        = ['Apache License (2.0)']
   s.summary         = "plugin to upload log events to Google Cloud Storage (GCS)"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"
   s.authors         = ["Elastic"]

--- a/spec/outputs/gcs/worker_pool_spec.rb
+++ b/spec/outputs/gcs/worker_pool_spec.rb
@@ -1,0 +1,27 @@
+# encoding: utf-8
+require 'logstash/outputs/gcs/worker_pool'
+
+describe LogStash::Outputs::Gcs::WorkerPool do
+  describe '#post' do
+    it 'runs the task in the same thread if synchronous' do
+      pool = LogStash::Outputs::Gcs::WorkerPool.new(5, true)
+      expect(pool.workers).to_not receive(:post)
+
+      pool.post { 1 + 2 }
+    end
+
+    it 'runs the task in a different thread if asynchronous' do
+      pool = LogStash::Outputs::Gcs::WorkerPool.new(5, false)
+      expect(pool.workers).to receive(:post)
+
+      pool.post { 1 + 2 }
+    end
+
+    it 'raises an error if the pool is already stopped' do
+      pool = LogStash::Outputs::Gcs::WorkerPool.new(5, true)
+      pool.stop!
+
+      expect{ pool.post{} }.to raise_error(RuntimeError)
+    end
+  end
+end

--- a/spec/outputs/google_cloud_storage_spec.rb
+++ b/spec/outputs/google_cloud_storage_spec.rb
@@ -10,7 +10,7 @@ describe LogStash::Outputs::GoogleCloudStorage do
   let(:key)    { "key" }
 
   subject { described_class.new(config) }
-  let(:config) { {"bucket" => "", "key_path" => "", "service_account" => "", "uploader_interval_secs" => 0.1 } }
+  let(:config) { {"bucket" => "", "key_path" => "", "service_account" => "", "uploader_interval_secs" => 0.1, "upload_synchronous" => true} }
 
   before(:each) do
     allow(Google::APIClient).to receive(:new).and_return(client)
@@ -23,37 +23,5 @@ describe LogStash::Outputs::GoogleCloudStorage do
 
   it "should register without errors" do
     expect { subject.register }.to_not raise_error
-  end
-
-  describe "file size based decider for uploading" do
-    let(:upload_queue) { Queue.new }
-    let(:content) { }
-    before(:each) do
-      allow(subject).to receive(:new_upload_queue).and_return(upload_queue)
-      subject.send(:initialize_upload_queue)
-      subject.send(:initialize_temp_directory)
-      subject.send(:initialize_path_factory)
-      subject.send(:open_current_file)
-      current_file = upload_queue.pop
-      File.write(current_file, content) if content
-      upload_queue.push(current_file)
-      subject.send(:initialize_next_log)
-    end
-
-    context "when spooled file is empty" do
-      let(:content) { nil }
-      it "doesn't get uploaded" do
-        expect(subject).to_not receive(:upload_object)
-        subject.send(:upload_from_queue)
-      end
-    end
-
-    context "when spooled file has content" do
-      let(:content) { "hello" }
-      it "gets uploaded" do
-        expect(subject).to receive(:upload_object)
-        subject.send(:upload_from_queue)
-      end
-    end
   end
 end

--- a/spec/outputs/google_cloud_storage_spec.rb
+++ b/spec/outputs/google_cloud_storage_spec.rb
@@ -4,7 +4,7 @@ require "google/api_client"
 require "tempfile"
 
 describe LogStash::Outputs::GoogleCloudStorage do
-  
+
   let(:client) { double("google-client") }
   let(:service_account) { double("service-account") }
   let(:key)    { "key" }


### PR DESCRIPTION
Change the old architecture of one upload thread that reads a queue of files to open to a new one where files to upload are pushed to a pool of workers only once they're ready to be uploaded.

This architecture simplifies things in a few ways:

 * Only files ready to upload are kept on the queue, no more sleep/poll/rotate if ready which seemed to be the source of race conditions.
 * There's exactly one place for special logic for synchronous uploads.
 * Consolidated logic for syncing/closing/deleting files.
 * Consolidated logic for testing if a log is ready to rotate.

The changes fix: #22, #5 and #15 

Locking still isn't fixed, it's just slightly less bad than it was before. Once this PR and the Java one get merged there'll be a nice clean path towards locking.