### PR TITLE
fixing race conditions in tests

### DIFF
--- a/lib/logstash/outputs/google_cloud_storage.rb
+++ b/lib/logstash/outputs/google_cloud_storage.rb
@@ -175,7 +175,7 @@ class LogStash::Outputs::GoogleCloudStorage < LogStash::Outputs::Base
   public
   def close
     @logger.debug('Stopping the plugin, uploading the remaining files.')
-    Stud.stop!(@registration_thread) unless @registration_thread.nil?
+    Thread.kill(@uploader_thread) unless @uploader_thread.nil?
 
     # Force rotate the log. If it contains data it will be submitted
     # to the work pool and will be uploaded before the plugin stops.
@@ -215,8 +215,7 @@ class LogStash::Outputs::GoogleCloudStorage < LogStash::Outputs::Base
 
   # start_uploader periodically sends flush events through the log rotater
   def start_uploader
-    Thread.new do
-      @registration_thread = Thread.current
+    @uploader_thread = Thread.new do
       Stud.interval(@uploader_interval_secs) do
         @log_rotater.writeln(nil)
       end

--- a/spec/outputs/gcs/temp_log_file_spec.rb
+++ b/spec/outputs/gcs/temp_log_file_spec.rb
@@ -68,7 +68,7 @@ shared_examples 'a log file' do
 
   describe '#time_since_sync' do
     it 'returns a delta' do
-      expect(Time).to receive(:now).and_return(30, 40, 50)
+      expect(Time).to receive(:now).and_return(Time.at(30), Time.at(40), Time.at(50))
 
       subject.fsync
 

--- a/spec/outputs/gcs/worker_pool_spec.rb
+++ b/spec/outputs/gcs/worker_pool_spec.rb
@@ -8,6 +8,7 @@ describe LogStash::Outputs::Gcs::WorkerPool do
       expect(pool.workers).to_not receive(:post)
 
       pool.post { 1 + 2 }
+      pool.stop!
     end
 
     it 'runs the task in a different thread if asynchronous' do
@@ -15,6 +16,7 @@ describe LogStash::Outputs::Gcs::WorkerPool do
       expect(pool.workers).to receive(:post)
 
       pool.post { 1 + 2 }
+      pool.stop!
     end
 
     it 'raises an error if the pool is already stopped' do

--- a/spec/outputs/google_cloud_storage_spec.rb
+++ b/spec/outputs/google_cloud_storage_spec.rb
@@ -23,5 +23,7 @@ describe LogStash::Outputs::GoogleCloudStorage do
 
   it "should register without errors" do
     expect { subject.register }.to_not raise_error
+
+    subject.close
   end
 end


### PR DESCRIPTION
Fixes #28 as far as I can tell. I ran with the same seed before and after the changes and it went from failing to passing.

The problems were that some background threads were being started by a few tests and weren't cleaned up at the end so they were triggering events in other tests.