### PR TITLE
Fix cyclic dependency in path_factory.rb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 4.0.1
+  - Fixes [#38](https://github.com/logstash-plugins/logstash-output-google_cloud_storage/issues/38) - Plugin doesn't start on logstash 7.1.1 - TypeError
+
 ## 4.0.0
   - Move to the Java Google Cloud client library for increased performance and stability.
   - **Breaking** If you use the old PKCS12 authentication keys, you will need to upgrade to

--- a/lib/logstash/outputs/gcs/path_factory.rb
+++ b/lib/logstash/outputs/gcs/path_factory.rb
@@ -80,7 +80,7 @@ module LogStash
               prefix: @prefix,
               host: Socket.gethostname,
               date: Time.now.strftime(@date_pattern),
-              partf: '%03d' % @part_number,
+              partf: '%03d' % (@part_number.nil? ? 0 : @part_number),
               uuid: SecureRandom.uuid
           }
         end

--- a/logstash-output-google_cloud_storage.gemspec
+++ b/logstash-output-google_cloud_storage.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-output-google_cloud_storage'
-  s.version         = '4.0.0'
+  s.version         = '4.0.1'
   s.licenses        = ['Apache-2.0']
   s.summary         = "plugin to upload log events to Google Cloud Storage (GCS)"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
In file lib/logstash/outputs/gcs/path_factory.rb is a cyclic dependency:
* @part_number is defined using method start_part
* start_part uses next_base
* next_base uses template_variables
* template_variables uses @part_number, before it's defined and cause error

This fix checks, if @part_number is nil. If yes, it provides fallback to 0, which is default value used in other places of file.

Fix for #38
