### PR TITLE
add codec support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 4.1.0
+  - Added ability to use Logstash codecs.
+
 ## 4.0.1
   - Fixes [#38](https://github.com/logstash-plugins/logstash-output-google_cloud_storage/issues/38) - Plugin doesn't start on logstash 7.1.1 - TypeError
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -1,6 +1,6 @@
 :plugin: google_cloud_storage
 :type: output
-:default_codec: plain
+:default_codec: line
 
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
@@ -264,10 +264,17 @@ Sets max file size in kbytes. 0 disable max file check.
 [id="plugins-{type}s-{plugin}-output_format"]
 ===== `output_format` 
 
-  * Value can be any of: `json`, `plain`
-  * Default value is `"plain"`
+  * Value can be any of: `json`, `plain`, `` (blank)
+  * Default value is `""`
+
+**Deprecated**, this feature will be removed in the next major release. Use codecs instead.
+
+  * If you are using the `json` value today, switch to the `json_lines` codec.
+  * If you are using the `plain` value today, switch to the `line` codec.
 
 The event format you want to store in files. Defaults to plain text.
+
+Note: if you want to use a codec you MUST not set this value.
 
 [id="plugins-{type}s-{plugin}-service_account"]
 ===== `service_account` 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -101,7 +101,7 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 | <<plugins-{type}s-{plugin}-log_file_prefix>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-max_concurrent_uploads>> |<<number,number>>|No
 | <<plugins-{type}s-{plugin}-max_file_size_kbytes>> |<<number,number>>|No
-| <<plugins-{type}s-{plugin}-output_format>> |<<string,string>>, one of `["json", "plain"]`|No
+| <<plugins-{type}s-{plugin}-output_format>> |<<string,string>>, one of `["json", "plain", nil]`|__Deprecated__
 | <<plugins-{type}s-{plugin}-service_account>> |<<string,string>>|__Deprecated__
 | <<plugins-{type}s-{plugin}-temp_directory>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-uploader_interval_secs>> |<<number,number>>|No
@@ -264,8 +264,8 @@ Sets max file size in kbytes. 0 disable max file check.
 [id="plugins-{type}s-{plugin}-output_format"]
 ===== `output_format` 
 
-  * Value can be any of: `json`, `plain`, `` (blank)
-  * Default value is `""`
+  * Value can be any of: `json`, `plain`, or no value
+  * Default value is no value
 
 **Deprecated**, this feature will be removed in the next major release. Use codecs instead.
 

--- a/lib/logstash/outputs/gcs/log_rotate.rb
+++ b/lib/logstash/outputs/gcs/log_rotate.rb
@@ -19,15 +19,15 @@ module LogStash
           rotate_log!
         end
 
-        # writeln writes a message and carriage-return character to the open
-        # log file, rotating and syncing it if necessary.
+        # write writes zero or more messages to the open log file
+        # rotating and syncing it if necessary.
         #
         # nil messages do not get written, but may cause the log to rotate
-        def writeln(message=nil)
+        def write(*messages)
           @lock.with_write_lock do
             rotate_log! if should_rotate?
 
-            @temp_file.write(message, "\n") unless message.nil?
+            @temp_file.write(*messages) unless messages.empty?
 
             @temp_file.fsync if @temp_file.time_since_sync >= @flush_interval_secs
           end

--- a/lib/logstash/outputs/google_cloud_storage.rb
+++ b/lib/logstash/outputs/google_cloud_storage.rb
@@ -104,7 +104,7 @@ class LogStash::Outputs::GoogleCloudStorage < LogStash::Outputs::Base
   config :max_file_size_kbytes, :validate => :number, :default => 10000
 
   # The event format you want to store in files. Defaults to plain text.
-  config :output_format, :validate => [ "json", "plain", "" ], :default => "", :deprecated => 'Use codec instead.'
+  config :output_format, :validate => [ "json", "plain", nil ], :default => nil, :deprecated => 'Use codec instead.'
 
   # Time pattern for log file, defaults to hourly files.
   # Must Time.strftime patterns: www.ruby-doc.org/core-2.0/Time.html#method-i-strftime
@@ -164,7 +164,7 @@ class LogStash::Outputs::GoogleCloudStorage < LogStash::Outputs::Base
     # do our own pseudo-codec processing. This should be removed in the
     # next major release.
     params['codec'] = LogStash::Plugin.lookup('codec', 'json_lines').new if @output_format == 'json'
-    params['codec'] = LogStash::Plugin.lookup('codec', 'plain').new if @output_format == 'line'
+    params['codec'] = LogStash::Plugin.lookup('codec', 'line').new if @output_format == 'plain'
 
     @workers = LogStash::Outputs::Gcs::WorkerPool.new(@max_concurrent_uploads, @upload_synchronous)
     initialize_temp_directory

--- a/logstash-output-google_cloud_storage.gemspec
+++ b/logstash-output-google_cloud_storage.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-output-google_cloud_storage'
-  s.version         = '4.0.1'
+  s.version         = '4.1.0'
   s.licenses        = ['Apache-2.0']
   s.summary         = "plugin to upload log events to Google Cloud Storage (GCS)"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"
@@ -18,16 +18,19 @@ Gem::Specification.new do |s|
   # Special flag to let us know this is actually a logstash plugin
   s.metadata = { "logstash_plugin" => "true", "logstash_group" => "output" }
 
+  # JARs
+  s.platform = 'java'
+
   # Gem dependencies
   s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
 
   s.add_runtime_dependency 'stud'
-  s.add_runtime_dependency 'logstash-codec-plain'
+  s.add_runtime_dependency 'logstash-codec-line'
+  s.add_runtime_dependency 'logstash-codec-json_lines'
   s.add_runtime_dependency 'mime-types', '~> 2' # last version compatible with ruby 2.x
   s.add_runtime_dependency 'concurrent-ruby' # use version bundled with Logstash to avoid platform mismatch on plugin install
-  s.add_development_dependency 'logstash-devutils'
 
-  # JARs
-  s.platform = 'java'
+  s.add_development_dependency 'logstash-devutils'
+end
 end
 

--- a/logstash-output-google_cloud_storage.gemspec
+++ b/logstash-output-google_cloud_storage.gemspec
@@ -32,5 +32,4 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency 'logstash-devutils'
 end
-end
 

--- a/spec/outputs/gcs/path_factory_spec.rb
+++ b/spec/outputs/gcs/path_factory_spec.rb
@@ -114,13 +114,13 @@ describe LogStash::Outputs::Gcs::PathFactory do
         builder.set_directory 'dir'
         builder.set_prefix 'pre'
         builder.set_include_host false
-        builder.set_date_pattern '%N'
+        builder.set_date_pattern '%s'
         builder.set_include_part true
         builder.set_include_uuid false
         builder.set_is_gzipped false
       end
       expect(pf.current_path).to include('part000')
-
+      sleep(1)
       pf.rotate_path!
       expect(pf.current_path).to include('part000')
     end

--- a/spec/outputs/google_cloud_storage_spec.rb
+++ b/spec/outputs/google_cloud_storage_spec.rb
@@ -51,9 +51,17 @@ describe LogStash::Outputs::GoogleCloudStorage do
 
     it 'should call the codec if output_format is blank' do
       encoded = encode_test({
-                      :output_format => '',
+                      :output_format => nil,
                       :event => {'message' => 'contents'}
                   })
+
+      expect(encoded).to eq("1970-01-01T00:00:00.000Z localhost contents\n")
+    end
+
+    it 'should call the codec if no output_format' do
+      encoded = encode_test({
+                                :event => {'message' => 'contents'}
+                            })
 
       expect(encoded).to eq("1970-01-01T00:00:00.000Z localhost contents\n")
     end
@@ -66,8 +74,8 @@ def encode_test(params)
       'service_account' => '',
       'uploader_interval_secs' => 10000,
       'upload_synchronous' => true,
-      'output_format' => params[:output_format]
   }
+  config['output_format'] = params[:output_format] if params[:output_format]
 
   rotater = double('rotater')
   allow(rotater).to receive(:on_rotate)

--- a/spec/outputs/google_cloud_storage_spec.rb
+++ b/spec/outputs/google_cloud_storage_spec.rb
@@ -1,6 +1,7 @@
 # encoding: utf-8
 require_relative "../spec_helper"
 require "tempfile"
+require "json"
 
 describe LogStash::Outputs::GoogleCloudStorage do
 
@@ -15,9 +16,78 @@ describe LogStash::Outputs::GoogleCloudStorage do
     allow(javaclient).to receive(:initialize_storage).and_return(:javastorage)
   end
 
-  it "should register without errors" do
+  it 'should register without errors' do
     expect { subject.register }.to_not raise_error
 
     subject.close
   end
+
+  describe '#encode' do
+    it 'should dump the event hash if output_format is json' do
+      encoded = encode_test({
+                                :output_format => 'json',
+                                :event => {'message' => 'contents'}
+                            })
+
+      expect(encoded.end_with?("\n")).to eq(true)
+
+      encoded_hash = JSON.parse(encoded)
+      expect(encoded_hash).to eq({
+                                     'message' => 'contents',
+                                     '@timestamp' => '1970-01-01T00:00:00.000Z',
+                                     'host' => 'localhost',
+                                     '@version' => '1'})
+    end
+
+    it 'should convert to a string if output_format is plain' do
+      encoded = encode_test({
+                      :output_format => 'plain',
+                      :event => {'message' => 'contents'}
+                  })
+
+      expect(encoded).to eq("1970-01-01T00:00:00.000Z localhost contents\n")
+
+    end
+
+    it 'should call the codec if output_format is blank' do
+      encoded = encode_test({
+                      :output_format => '',
+                      :event => {'message' => 'contents'}
+                  })
+
+      expect(encoded).to eq("1970-01-01T00:00:00.000Z localhost contents\n")
+    end
+  end
+end
+
+def encode_test(params)
+  config = {
+      'bucket' => '',
+      'service_account' => '',
+      'uploader_interval_secs' => 10000,
+      'upload_synchronous' => true,
+      'output_format' => params[:output_format]
+  }
+
+  rotater = double('rotater')
+  allow(rotater).to receive(:on_rotate)
+  allow(rotater).to receive(:rotate_log!)
+
+  allow(LogStash::Outputs::Gcs::LogRotate).to receive(:new).and_return(rotater)
+
+  gcsout = LogStash::Outputs::GoogleCloudStorage.new(config)
+  gcsout.disable_uploader = true
+  gcsout.register
+
+  event = LogStash::Event.new(params[:event])
+  event.timestamp = LogStash::Timestamp.at(0)
+  event.set('host', 'localhost')
+
+  value = ''
+  allow(rotater).to receive(:write){ |line| value = line }
+
+  gcsout.multi_receive([event])
+  gcsout.close
+
+  value
 end


### PR DESCRIPTION
This is a reboot of #34 by @josephlewis42. 

I essentially only rebased against latest changes and added some minor fixes. 

This PR adds proper support for codecs and deprecates the `output_format` config option. It is backward compatible in the sense that the `output_format` option will be translated to the equivalent codec option; `output_format => json` becomes `codec => json_lines` and `output_format => plain` becomes `codec => line`.


